### PR TITLE
window.py: put similar imports in one line

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -28,11 +28,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-from gi.repository import Adw
-from gi.repository import Gtk
-from gi.repository import Gio
-from gi.repository import GLib
-from gi.repository import GObject
+from gi.repository import Adw, Gtk, Gio, GLib, GObject
 
 from cavalier.settings import CavalierSettings
 from cavalier.drawing_area import CavalierDrawingArea


### PR DESCRIPTION
Don't know if this is better than before, but the other files do it this way too.